### PR TITLE
Implementation of the method body writer

### DIFF
--- a/sample.toml
+++ b/sample.toml
@@ -6,6 +6,7 @@ name = "users"
 
 	[[groups.endpoints]]
 	route = "/find"
+	name = "find_user_by_id"
 	http_verb = "Get"
 	query_param = {name = "user_id", field_type = "String"}
 	success_code = 200
@@ -19,6 +20,7 @@ name = "users"
 
 	[[groups.endpoints]]
 	route = "/find/all"
+	name = "find_all_users"
 	http_verb = "Get"
 	success_code = 200
 	return_model = """\

--- a/sample.toml
+++ b/sample.toml
@@ -1,6 +1,7 @@
 title = "API Title"
 version = "V0.1"
 db_uri = "mongodb://127.0.0.1:27017/"
+db_name = "tests"
 
 [[groups]]
 name = "users"
@@ -16,7 +17,7 @@ collection_name = "users"
 	return_model = """\
 	{
 		name: String,
-		age: u16,
+		age: f32,
 		email: String,
 	}"""
 

--- a/sample.toml
+++ b/sample.toml
@@ -10,8 +10,9 @@ name = "users"
 	http_verb = "Get"
 	query_param = {name = "user_id", field_type = "String"}
 	success_code = 200
+	return_model_name = "UserResponse"
 	return_model = """\
-	struct UserResponse {
+	{
 		name: String,
 		age: u16,
 		email: String,
@@ -23,7 +24,8 @@ name = "users"
 	name = "find_all_users"
 	http_verb = "Get"
 	success_code = 200
+	return_model_name = "UserResponseList"
 	return_model = """\
-	struct UserResponseList {
+	{
 		users: Vec<UserResponse>,
 	}"""

--- a/sample.toml
+++ b/sample.toml
@@ -1,8 +1,10 @@
 title = "API Title"
 version = "V0.1"
+db_uri = "mongodb://127.0.0.1:27017/"
 
 [[groups]]
 name = "users"
+collection_name = "users"
 
 	[[groups.endpoints]]
 	route = "/find"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ fn main() {
     writers::dir_builder::build(base_output_dir_str).unwrap();
 
     // writers::file_writer
-    let endpoints = toml_reader.toml_data.get_all_endpoints();
-    let file_writer = writers::file_writer::write(&endpoints).unwrap();
+    // let endpoints = toml_reader.toml_data.get_all_endpoints();
+    let file_writer = writers::file_writer::write(&toml_reader.toml_data).unwrap();
 
     // for path_str in &path_list {
     // let path = Path::new(path_str);

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -97,6 +97,7 @@ pub struct Endpoint {
     pub query_param: Option<QueryParam>,
     // TODO: eventually this success code needs to be validated and wrapped in a StatusCode enum.
     pub success_code: u16,
+    pub return_model_name: String,
     pub return_model: String,
 }
 

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -91,12 +91,12 @@ impl EndpointGroup {
 /// transaction in the API as a whole.
 #[derive(Deserialize, Debug, Clone)]
 pub struct Endpoint {
-    route: String,
-    http_verb: HTTPVerbs,
-    query_param: Option<QueryParam>,
+    pub route: String,
+    pub http_verb: HTTPVerbs,
+    pub query_param: Option<QueryParam>,
     // TODO: eventually this success code needs to be validated and wrapped in a StatusCode enum.
-    success_code: u16,
-    return_model: String,
+    pub success_code: u16,
+    pub return_model: String,
 }
 
 /// Made for requests (`GET`s) that need to take in a URL query string parameter.
@@ -104,14 +104,14 @@ pub struct Endpoint {
 /// The `field_type` is a non-exhaustive enum of valid data types which are to be
 /// used later in conjunction with the `writer` mod.
 #[derive(Deserialize, Debug, Clone)]
-struct QueryParam {
+pub struct QueryParam {
     name: String,
     field_type: UnitTypes,
 }
 
 /// Very small (and frankly hacky) list of accepted data types (think primitives but worse).
 #[derive(Deserialize, Debug, Clone)]
-enum UnitTypes {
+pub enum UnitTypes {
     String,
     U32,
     I32,
@@ -125,7 +125,7 @@ enum UnitTypes {
 /// Eventually these will require their own valid implementation for use with
 /// the `writer` mod.
 #[derive(Deserialize, Debug, Clone)]
-enum HTTPVerbs {
+pub enum HTTPVerbs {
     Get,
     Post,
     Delete,

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -8,8 +8,8 @@
 //! ### NOTE:
 //! - All of the enums and structs used to parse *must* implement the `serde::Deserialize` trait.
 
-use hyper::StatusCode;
 use serde_derive::Deserialize;
+use std::fmt;
 use toml;
 
 /// Provides all of the top-level unpacking (deserialization) from the toml file.
@@ -92,6 +92,7 @@ impl EndpointGroup {
 #[derive(Deserialize, Debug, Clone)]
 pub struct Endpoint {
     pub route: String,
+    pub name: String,
     pub http_verb: HTTPVerbs,
     pub query_param: Option<QueryParam>,
     // TODO: eventually this success code needs to be validated and wrapped in a StatusCode enum.
@@ -105,8 +106,8 @@ pub struct Endpoint {
 /// used later in conjunction with the `writer` mod.
 #[derive(Deserialize, Debug, Clone)]
 pub struct QueryParam {
-    name: String,
-    field_type: UnitTypes,
+    pub name: String,
+    pub field_type: UnitTypes,
 }
 
 /// Very small (and frankly hacky) list of accepted data types (think primitives but worse).
@@ -117,6 +118,19 @@ pub enum UnitTypes {
     I32,
     U16,
     I16,
+}
+
+impl fmt::Display for UnitTypes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let fmt_string = match self {
+            UnitTypes::String => "String",
+            UnitTypes::U32 => "u32",
+            UnitTypes::I32 => "i32",
+            UnitTypes::U16 => "u16",
+            UnitTypes::I16 => "i16",
+        };
+        write!(f, "{}", fmt_string)
+    }
 }
 
 // TODO: replace this with a `std` lib enum of http verbs.

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -23,6 +23,7 @@ use toml;
 pub struct WebAPI {
     title: String,
     version: String,
+    pub db_uri: String,
     pub groups: Vec<EndpointGroup>,
 }
 
@@ -67,6 +68,7 @@ impl WebAPI {
 #[derive(Deserialize, Debug)]
 pub struct EndpointGroup {
     name: String,
+    collection_name: String,
     pub endpoints: Vec<Endpoint>,
 }
 

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -68,7 +68,7 @@ impl WebAPI {
 /// Mainly exists to conform easily to TOML structure.
 #[derive(Deserialize, Debug)]
 pub struct EndpointGroup {
-    name: String,
+    pub name: String,
     pub collection_name: String,
     pub endpoints: Vec<Endpoint>,
 }
@@ -76,7 +76,7 @@ pub struct EndpointGroup {
 impl EndpointGroup {
     /// Iterates over the endpoints the group owns and returns
     /// a `Vec` of refences.
-    fn get_endpoints(&self) -> Vec<&Endpoint> {
+    pub fn get_endpoints(&self) -> Vec<&Endpoint> {
         let mut all_endpoints = Vec::new();
         for endpoint in &self.endpoints {
             all_endpoints.push(endpoint);

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -24,6 +24,7 @@ pub struct WebAPI {
     title: String,
     version: String,
     pub db_uri: String,
+    pub db_name: String,
     pub groups: Vec<EndpointGroup>,
 }
 
@@ -68,7 +69,7 @@ impl WebAPI {
 #[derive(Deserialize, Debug)]
 pub struct EndpointGroup {
     name: String,
-    collection_name: String,
+    pub collection_name: String,
     pub endpoints: Vec<Endpoint>,
 }
 

--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -89,7 +89,7 @@ impl EndpointGroup {
 ///
 /// This is the single struct that should have the most meaningful data specific to a single
 /// transaction in the API as a whole.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Endpoint {
     route: String,
     http_verb: HTTPVerbs,
@@ -103,14 +103,14 @@ pub struct Endpoint {
 ///
 /// The `field_type` is a non-exhaustive enum of valid data types which are to be
 /// used later in conjunction with the `writer` mod.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 struct QueryParam {
     name: String,
     field_type: UnitTypes,
 }
 
 /// Very small (and frankly hacky) list of accepted data types (think primitives but worse).
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 enum UnitTypes {
     String,
     U32,
@@ -124,7 +124,7 @@ enum UnitTypes {
 ///
 /// Eventually these will require their own valid implementation for use with
 /// the `writer` mod.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 enum HTTPVerbs {
     Get,
     Post,

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -33,7 +33,6 @@ impl BodyBuilder for HttpGet {
         // method signature handling
         full_output_string.push_str(&self.method_signature_string());
 
-
         // method boyd handling
         full_output_string.push_str(&self.method_body_string());
 
@@ -74,7 +73,7 @@ impl BodyBuilder for HttpGet {
 
         // assemble the status code and the HttpResponse
         let status_code = format!(
-            "let status_code = StatusCode::from_u16({}).unwrap();",
+            "let status_code = http::StatusCode::from_u16({}).unwrap();",
             &self.endpoint.success_code
         );
 

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -24,19 +24,32 @@ impl BodyBuilder for HttpGet {
     fn get_body_string_from_endpoint(&self) -> String {
         let mut full_output_string = String::new();
 
-        let macro_header_string = self.macro_string();
-        full_output_string.push_str(&macro_header_string);
+        // macro header handling
+        full_output_string.push_str(&self.macro_string());
+
+        // method signature handling
+        full_output_string.push_str(&self.method_signature_string());
 
         full_output_string
     }
 
     fn macro_string(&self) -> String {
         let route = &self.endpoint.route;
-        let output_string = format!("#[get(\"{}\")]\n", route);
-        output_string
+        format!("#[get(\"{}\")]\n", route)
     }
 
-    fn method_signature_string(&self) -> String {String::new()}
+    fn method_signature_string(&self) -> String {
+        let mut output_string = String::new();
+
+        let mut param_string = String::new();
+
+        if let Some(query) =  &self.endpoint.query_param {
+            param_string.push_str(&format!("{}: {}", query.name, query.field_type));
+        }
+
+        let fn_name = &self.endpoint.name;
+        format!("async fn {}({}) -> impl Responder {{\n", fn_name, param_string)
+    }
 
     fn method_body_string(&self) -> String {String::new()}
 }

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -5,5 +5,52 @@
 //!
 //! Should ONLY ever be written to a file AFTER the header string has been
 //! written to it (else compile will fail).
+//!
+//! FIXME: The name is a bit misleading, in reality it just composes the
+//! output file strings without writing them. Maybe a refactor is in the works?
+//! Or maybe the module should actually write to IO.
+//! Worst case we can name swap between this mod and `HTTPGetEndpointBuilder`.
 
 use crate::readers::assembler::Endpoint;
+
+/// Base struct for the implementations of a single
+/// actix `GET` endpoint.
+struct HTTPGetBodyWriter {
+}
+
+
+/// Note: none of these methods actually require an instanciation mainly because
+/// the writers only really expose one method to the public: `write`.
+impl HTTPGetBodyWriter {
+    /// Top-level function for the struct, returns final output string.
+    ///
+    /// Based entirely off of an `Endpoint` reference, decomposing it
+    /// into the final output string headed to file.
+    pub fn write(endpoint: &Endpoint) -> String {
+        String::from("lol")
+    }
+
+}
+
+
+/// This trait is to be shared amongst all of the HTTP<verb>BodyWriters, and has
+/// common util functions for them all so that unpacking calls work polymorphically
+trait HTTPBodyWriter {
+    /// Top-level function for the struct, returns final output string.
+    ///
+    /// Based entirely off of an `Endpoint` reference, decomposing it
+    /// into the final output string headed to file.
+    pub fn new(endpoint: &Endpoint) -> String;
+
+    /// Returns the actix macro string for the specific HTTP<Verb> builder
+    fn macro_string() -> String;
+
+    /// Returns the actual method signature string for the actix method
+    fn method_signature_string() -> String;
+
+    /// Returns the body string of the actix method.
+    ///
+    /// This method can call many helper methods as long as the result
+    /// returned is final and output-ready.
+    fn method_body_string() -> String;
+}

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -33,7 +33,7 @@ impl BodyBuilder for HttpGet {
         // method signature handling
         full_output_string.push_str(&self.method_signature_string());
 
-        // method boyd handling
+        // method body handling
         full_output_string.push_str(&self.method_body_string());
 
         full_output_string

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -22,10 +22,19 @@ impl BodyBuilder for HttpGet {
     }
 
     fn get_body_string_from_endpoint(&self) -> String {
-        format!("{:#?}", self.endpoint)
+        let mut full_output_string = String::new();
+
+        let macro_header_string = self.macro_string();
+        full_output_string.push_str(&macro_header_string);
+
+        full_output_string
     }
 
-    fn macro_string(&self) -> String {String::new()}
+    fn macro_string(&self) -> String {
+        let route = &self.endpoint.route;
+        let output_string = format!("#[get(\"{}\")]\n", route);
+        output_string
+    }
 
     fn method_signature_string(&self) -> String {String::new()}
 

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -1,0 +1,9 @@
+//! Writer module that writes most of the generated code in the form of
+//! the actual actix endpoint methods.
+//!
+//! Relies on data from `Endpoint` structs.
+//!
+//! Should ONLY ever be written to a file AFTER the header string has been
+//! written to it (else compile will fail).
+
+use crate::readers::assembler::Endpoint;

--- a/src/writers/file_writer/body_writer/mod.rs
+++ b/src/writers/file_writer/body_writer/mod.rs
@@ -1,4 +1,4 @@
-//! Writer module that writes most of the generated code in the form of
+//! StringBuilder module that writes most of the generated code in the form of
 //! the actual actix endpoint methods.
 //!
 //! Relies on data from `Endpoint` structs.
@@ -13,44 +13,48 @@
 
 use crate::readers::assembler::Endpoint;
 
-/// Base struct for the implementations of a single
-/// actix `GET` endpoint.
-struct HTTPGetBodyWriter {
-}
 
+pub struct HttpGet{endpoint: Endpoint}
 
-/// Note: none of these methods actually require an instanciation mainly because
-/// the writers only really expose one method to the public: `write`.
-impl HTTPGetBodyWriter {
-    /// Top-level function for the struct, returns final output string.
-    ///
-    /// Based entirely off of an `Endpoint` reference, decomposing it
-    /// into the final output string headed to file.
-    pub fn write(endpoint: &Endpoint) -> String {
-        String::from("lol")
+impl BodyBuilder for HttpGet {
+    fn new(endpoint: &Endpoint) -> HttpGet {
+        HttpGet{endpoint: endpoint.clone()}
     }
 
+    fn get_body_string_from_endpoint(&self) -> String {
+        format!("{:#?}", self.endpoint)
+    }
+
+    fn macro_string(&self) -> String {String::new()}
+
+    fn method_signature_string(&self) -> String {String::new()}
+
+    fn method_body_string(&self) -> String {String::new()}
 }
 
 
-/// This trait is to be shared amongst all of the HTTP<verb>BodyWriters, and has
+/// This trait is to be shared amongst all of the HTTP<verb>BodyStringBuilders, and has
 /// common util functions for them all so that unpacking calls work polymorphically
-trait HTTPBodyWriter {
+pub trait BodyBuilder {
+
+    /// Dummy constructor for allowing trait usage
+    fn new(endpoint_ref: &Endpoint) -> Self;
+
     /// Top-level function for the struct, returns final output string.
     ///
     /// Based entirely off of an `Endpoint` reference, decomposing it
     /// into the final output string headed to file.
-    pub fn new(endpoint: &Endpoint) -> String;
+    fn get_body_string_from_endpoint(&self) -> String;
 
     /// Returns the actix macro string for the specific HTTP<Verb> builder
-    fn macro_string() -> String;
+    fn macro_string(&self) -> String;
 
     /// Returns the actual method signature string for the actix method
-    fn method_signature_string() -> String;
+    fn method_signature_string(&self) -> String;
 
     /// Returns the body string of the actix method.
     ///
     /// This method can call many helper methods as long as the result
     /// returned is final and output-ready.
-    fn method_body_string() -> String;
+    fn method_body_string(&self) -> String;
 }

--- a/src/writers/file_writer/header_writer/mod.rs
+++ b/src/writers/file_writer/header_writer/mod.rs
@@ -36,7 +36,7 @@ impl HeaderBuilder {
         let mut full_import_string = format!("use {}::{{", parent_actix_import);
         let child_imports = actix_imports.join(",");
         // asemble the full import string
-        full_import_string.push_str(&format!("{}}};", child_imports));
+        full_import_string.push_str(&format!("{}}};\n", child_imports));
 
         full_import_string
     }

--- a/src/writers/file_writer/header_writer/mod.rs
+++ b/src/writers/file_writer/header_writer/mod.rs
@@ -6,8 +6,6 @@
 //!
 //! Header string includes module declarations, docstrings, and imports.
 
-use crate::readers::assembler::Endpoint;
-
 /// Acts just as a placeholder facade for the header string operations.
 ///
 /// Since no real data needs to be stored long term, it's easier to just have
@@ -17,7 +15,7 @@ pub struct HeaderBuilder {}
 impl HeaderBuilder {
     /// Top-level function for the struct that returns the final,
     /// assembled header string from endpoint data.
-    pub fn get_header_string_from_endpoint(endpoint: &Endpoint) -> String {
+    pub fn get_header_string() -> String {
         HeaderBuilder::get_import_string()
     }
 
@@ -28,7 +26,17 @@ impl HeaderBuilder {
     fn get_import_string() -> String {
         // TODO: this method might be better if it read data in from another source
         let parent_actix_import = "actix_web";
-        let actix_imports = ["middleware", "web", "App", "HttpRequest", "HttpServer"];
+        let actix_imports = [
+            "middleware",
+            "web",
+            "App",
+            "HttpRequest",
+            "HttpServer",
+            "http",
+            "get",
+            "HttpResponse",
+            "Responder",
+        ];
 
         // assemble the final import string
 

--- a/src/writers/file_writer/http_get_writer/mod.rs
+++ b/src/writers/file_writer/http_get_writer/mod.rs
@@ -5,7 +5,7 @@
 //! this code tries to hide as much of the actual interface it works with
 //! in order to simplify the top-level calls that the `file_writer` mod makes.
 
-use super::body_writer::HTTPGetBodyWriter;
+use super::body_writer::{BodyBuilder, HttpGet};
 use super::header_writer::HeaderBuilder;
 use crate::readers::assembler::Endpoint;
 
@@ -28,9 +28,14 @@ impl HTTPGetEndpointBuilder {
     pub fn create_endpoint(&self, endpoint: &Endpoint) -> String {
         let mut full_endpoint_string = String::new();
 
-        // start assembling the strings and pushing onto the final one
+        // get and concat the header string to the output string
         let header_string = HeaderBuilder::get_header_string_from_endpoint(endpoint);
         full_endpoint_string.push_str(&header_string);
+
+        // the full method body string is next
+        let body_string_generator: HttpGet = BodyBuilder::new(endpoint);
+        let body_string = body_string_generator.get_body_string_from_endpoint();
+        full_endpoint_string.push_str(&body_string);
 
         full_endpoint_string
     }

--- a/src/writers/file_writer/http_get_writer/mod.rs
+++ b/src/writers/file_writer/http_get_writer/mod.rs
@@ -28,10 +28,6 @@ impl HTTPGetEndpointBuilder {
     pub fn create_endpoint(&self, endpoint: &Endpoint) -> String {
         let mut full_endpoint_string = String::new();
 
-        // get and concat the header string to the output string
-        let header_string = HeaderBuilder::get_header_string_from_endpoint(endpoint);
-        full_endpoint_string.push_str(&header_string);
-
         // the full method body string is next
         let body_string_generator: HttpGet = BodyBuilder::new(endpoint);
         let body_string = body_string_generator.get_body_string_from_endpoint();

--- a/src/writers/file_writer/http_get_writer/mod.rs
+++ b/src/writers/file_writer/http_get_writer/mod.rs
@@ -5,6 +5,7 @@
 //! this code tries to hide as much of the actual interface it works with
 //! in order to simplify the top-level calls that the `file_writer` mod makes.
 
+use super::body_writer::HTTPGetBodyWriter;
 use super::header_writer::HeaderBuilder;
 use crate::readers::assembler::Endpoint;
 

--- a/src/writers/file_writer/main_method_writer/mod.rs
+++ b/src/writers/file_writer/main_method_writer/mod.rs
@@ -1,0 +1,59 @@
+//! Writes a single functions - `main`. Has the code to run the async actix function.
+
+use crate::readers::assembler::Endpoint;
+
+/// Interface for the main method string builder.
+pub struct MainMethodBuilder {}
+
+impl MainMethodBuilder {
+    pub fn get_main_method_string() -> String {
+        // output string-to-be
+        let mut full_output_string = String::new();
+
+        // import header string handling
+        full_output_string.push_str(&Self::get_main_method_import_string());
+
+        // method signature handling
+        full_output_string.push_str(&Self::method_signature_string());
+
+        // method body handling
+        full_output_string.push_str(&Self::method_body_string());
+
+        full_output_string
+    }
+
+    /// Get static method string for `main`
+    fn get_main_method_import_string() -> String {
+        format!(
+            "
+            use tokio;
+            mod users;
+            "
+        )
+    }
+
+    /// Returns a string with the method signature that has the
+    /// `tokio async` macro header.
+    fn method_signature_string() -> String {
+        format!(
+            "
+            #[tokio::main]
+            async fn main() {{
+            "
+        )
+    }
+
+    /// Main method body string
+    fn method_body_string() -> String {
+        format!(
+            "
+                let db = users::utils::DB::init().await.unwrap();
+                let col = db.get_collection();
+                let user_id = String::from(\"123\");
+                let user = users::utils::find_user_by_id_util(user_id, col).await;
+                println!(\"{{:#?}}\", user);
+            }}
+            "
+        )
+    }
+}

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -17,7 +17,17 @@ pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {
         let endpoint_string = writer.create_endpoint(endpoint);
         full_output_string.push_str(&format!("{}\n", endpoint_string));
     }
+
+    // printing out the route file string
     println!("{}", full_output_string);
+
+    // now handle the util file string/IO
+    let db_uri = String::from("test");
+    let util_builder = util_writer::UtilBuilder::new(db_uri);
+    let endpoint = endpoints.get(0).unwrap(); // XXX: dont use this for long please
+    let util_str = util_builder.get_util_method_string(endpoint);
+
+    println!("{}", util_str);
 
     Ok(())
 }

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -30,7 +30,9 @@ pub fn write(api_config: &WebAPI) -> std::io::Result<()> {
     // create a util_method builder and generate the util file string
     // for all of the endpoints at once
     let db_uri = api_config.db_uri.clone();
-    let util_builder = util_writer::UtilBuilder::new(db_uri);
+    let db_name = api_config.db_name.clone();
+    let collection_name = api_config.groups.get(0).unwrap().collection_name.clone();
+    let util_builder = util_writer::UtilBuilder::new(db_uri, db_name, collection_name);
     let util_str = util_builder.get_util_method_string(endpoints);
 
     println!("{}", util_str);

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -1,3 +1,4 @@
+pub mod body_writer;
 pub mod header_writer;
 pub mod http_get_writer;
 use crate::readers::assembler::Endpoint;

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -1,6 +1,7 @@
 pub mod body_writer;
 pub mod header_writer;
 pub mod http_get_writer;
+pub mod util_writer;
 use crate::readers::assembler::Endpoint;
 
 pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -5,10 +5,18 @@ use crate::readers::assembler::Endpoint;
 
 pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {
     let writer = http_get_writer::HTTPGetEndpointBuilder::new();
+
+    let mut full_output_string = String::new();
+
+    // get and concat the header string to the output string
+    let header_string = header_writer::HeaderBuilder::get_header_string();
+    full_output_string.push_str(&header_string);
+
     for endpoint in endpoints {
         let endpoint_string = writer.create_endpoint(endpoint);
-        // TODO: placeholder code obviously
-        println!("{}", endpoint_string);
+        full_output_string.push_str(&format!("{}\n", endpoint_string));
     }
+    println!("{}", full_output_string);
+
     Ok(())
 }

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -2,40 +2,62 @@ pub mod body_writer;
 pub mod header_writer;
 pub mod http_get_writer;
 pub mod util_writer;
-use crate::readers::assembler::{Endpoint, WebAPI};
+use crate::readers::assembler::{Endpoint, EndpointGroup, WebAPI};
+use util_writer::database_generator::DatabaseInfo;
 
 pub fn write(api_config: &WebAPI) -> std::io::Result<()> {
-    // total output string to-be
-    let mut full_output_string = String::new();
+    for group in &api_config.groups {
+        let collection_name = group.collection_name.clone();
+        let db_info = DatabaseInfo::from_web_api(api_config, collection_name);
+        let util_file_string =
+            FileWriterAssembler::get_util_method_string_for_group(db_info, group);
+        println!(
+            "util file string for group with name {}:\n{}",
+            &group.name, &util_file_string
+        );
+    }
+    Ok(())
+}
 
-    // extract the list of endpoints for ease of borrow
-    let endpoints = &api_config.get_all_endpoints();
+/// Holds the actual implementation of the `write()` implemented.
+///
+/// We really only need some of the `WebAPI` data, so it's just easier to work
+/// with the data like this.
+///
+/// Also we can now tear apart the groups and generate strings `EndpointGroup`-wise
+struct FileWriterAssembler;
 
-    // get and concat the header string to the output string
-    let header_string = header_writer::HeaderBuilder::get_header_string();
-    full_output_string.push_str(&header_string);
+impl FileWriterAssembler {
+    /// Gets the file ready actix route code that should go in `src/<group_name>/routes.rs`
+    fn get_actix_routes_string_for_group(group: EndpointGroup) -> String {
+        // total output string to-be
+        let mut full_output_string = String::new();
 
-    // FIXME: this name is bad; this comment shouldn't be needed
-    // writer responsible for writing actix endpoint code
-    let writer = http_get_writer::HTTPGetEndpointBuilder::new();
-    // for each endpoint, write the actix route method code
-    for endpoint in endpoints {
-        let endpoint_string = writer.create_endpoint(endpoint);
-        full_output_string.push_str(&format!("{}\n", endpoint_string));
+        // get and concat the header string to the output string
+        let header_string = header_writer::HeaderBuilder::get_header_string();
+        full_output_string.push_str(&header_string);
+
+        // FIXME: this name is bad; this comment shouldn't be needed
+        // writer responsible for writing actix endpoint code
+        let writer = http_get_writer::HTTPGetEndpointBuilder::new();
+
+        // for each endpoint, write the actix route method code
+        for endpoint in &group.get_endpoints() {
+            let endpoint_string = writer.create_endpoint(endpoint);
+            full_output_string.push_str(&format!("{}\n", endpoint_string));
+        }
+
+        full_output_string
     }
 
-    // printing out the route file string
-    println!("{}", full_output_string);
+    fn get_util_method_string_for_group(db_info: DatabaseInfo, group: &EndpointGroup) -> String {
+        let endpoints = &group.get_endpoints();
 
-    // create a util_method builder and generate the util file string
-    // for all of the endpoints at once
-    let db_uri = api_config.db_uri.clone();
-    let db_name = api_config.db_name.clone();
-    let collection_name = api_config.groups.get(0).unwrap().collection_name.clone();
-    let util_builder = util_writer::UtilBuilder::new(db_uri, db_name, collection_name);
-    let util_str = util_builder.get_util_method_string(endpoints);
+        // create a util_method builder and generate the util file string
+        // for all of the endpoints at once
+        let util_builder = util_writer::UtilBuilder::new(db_info);
+        let util_str = util_builder.get_util_method_string(endpoints);
 
-    println!("{}", util_str);
-
-    Ok(())
+        util_str
+    }
 }

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -2,17 +2,23 @@ pub mod body_writer;
 pub mod header_writer;
 pub mod http_get_writer;
 pub mod util_writer;
-use crate::readers::assembler::Endpoint;
+use crate::readers::assembler::{Endpoint, WebAPI};
 
-pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {
-    let writer = http_get_writer::HTTPGetEndpointBuilder::new();
-
+pub fn write(api_config: &WebAPI) -> std::io::Result<()> {
+    // total output string to-be
     let mut full_output_string = String::new();
+
+    // extract the list of endpoints for ease of borrow
+    let endpoints = &api_config.get_all_endpoints();
 
     // get and concat the header string to the output string
     let header_string = header_writer::HeaderBuilder::get_header_string();
     full_output_string.push_str(&header_string);
 
+    // FIXME: this name is bad; this comment shouldn't be needed
+    // writer responsible for writing actix endpoint code
+    let writer = http_get_writer::HTTPGetEndpointBuilder::new();
+    // for each endpoint, write the actix route method code
     for endpoint in endpoints {
         let endpoint_string = writer.create_endpoint(endpoint);
         full_output_string.push_str(&format!("{}\n", endpoint_string));
@@ -21,8 +27,9 @@ pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {
     // printing out the route file string
     println!("{}", full_output_string);
 
-    // now handle the util file string/IO
-    let db_uri = String::from("test");
+    // create a util_method builder and generate the util file string
+    // for all of the endpoints at once
+    let db_uri = api_config.db_uri.clone();
     let util_builder = util_writer::UtilBuilder::new(db_uri);
     let util_str = util_builder.get_util_method_string(endpoints);
 

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -24,8 +24,7 @@ pub fn write(endpoints: &Vec<&Endpoint>) -> std::io::Result<()> {
     // now handle the util file string/IO
     let db_uri = String::from("test");
     let util_builder = util_writer::UtilBuilder::new(db_uri);
-    let endpoint = endpoints.get(0).unwrap(); // XXX: dont use this for long please
-    let util_str = util_builder.get_util_method_string(endpoint);
+    let util_str = util_builder.get_util_method_string(endpoints);
 
     println!("{}", util_str);
 

--- a/src/writers/file_writer/util_writer/database_generator.rs
+++ b/src/writers/file_writer/util_writer/database_generator.rs
@@ -1,9 +1,13 @@
+//! This module has all of the actual (large) database string generator code,
+//! if DB related code needs to be added/edited this is the first point of contact.
+
+/// Generates a fully contained/functional database system using mongodb.
+///
+/// Main interface to be used in other generated methods is:
+/// `DB::get_collection(db_name, collection)`.
 pub fn get_database_setup_string(db_uri: &String) -> String {
     format!(
         "
-            use mongodb::bson::{{doc, document::Document, oid::ObjectId, Bson}};
-            use mongodb::{{options::ClientOptions, Client, Collection}};
-
             pub struct DB {{
                 pub client: Client,
                 }}
@@ -24,5 +28,15 @@ pub fn get_database_setup_string(db_uri: &String) -> String {
             }}
             ",
         db_uri
+    )
+}
+
+/// Just returns the import header needed to cover all of the mongodb imports.
+pub fn get_database_import_string() -> String {
+    String::from(
+        "\
+        use mongodb::bson::{doc, document::Document, oid::ObjectId, Bson};
+        use mongodb::{options::ClientOptions, Client, Collection};
+        ",
     )
 }

--- a/src/writers/file_writer/util_writer/database_generator.rs
+++ b/src/writers/file_writer/util_writer/database_generator.rs
@@ -1,0 +1,28 @@
+pub fn get_database_setup_string(db_uri: &String) -> String {
+    format!(
+        "
+            use mongodb::bson::{{doc, document::Document, oid::ObjectId, Bson}};
+            use mongodb::{{options::ClientOptions, Client, Collection}};
+
+            pub struct DB {{
+                pub client: Client,
+                }}
+
+            impl DB {{
+                pub async fn init() -> Result<Self> {{
+                    let mut client_options = ClientOptions::parse(\"{}\").await?;
+                    client_options.app_name = Some(\"TEST\".to_string());
+                    Ok(Self {{
+                        client: Client::with_options(client_options)?,
+                    }})
+                }}
+
+                pub fn get_collection(&self, db_name: String, collection: String) -> Collection {{
+                    self.client.database(db_name).collection(collection)
+                }}
+
+            }}
+            ",
+        db_uri
+    )
+}

--- a/src/writers/file_writer/util_writer/database_generator.rs
+++ b/src/writers/file_writer/util_writer/database_generator.rs
@@ -5,7 +5,11 @@
 ///
 /// Main interface to be used in other generated methods is:
 /// `DB::get_collection(db_name, collection)`.
-pub fn get_database_setup_string(db_uri: &String) -> String {
+pub fn get_database_setup_string(
+    db_uri: &String,
+    db_name: &String,
+    collection_name: &String,
+) -> String {
     format!(
         "
             pub struct DB {{
@@ -20,12 +24,12 @@ pub fn get_database_setup_string(db_uri: &String) -> String {
                     Ok(DB {{ client }})
                 }}
 
-                pub fn get_collection(&self, db_name: &String, collection: &String) -> Collection {{
-                    self.client.database(db_name).collection(collection)
+                pub fn get_collection(&self) -> Collection {{
+                    self.client.database(\"{}\").collection(\"{}\")
                 }}
             }}
            ",
-        db_uri
+        db_uri, db_name, collection_name,
     )
 }
 

--- a/src/writers/file_writer/util_writer/database_generator.rs
+++ b/src/writers/file_writer/util_writer/database_generator.rs
@@ -13,20 +13,18 @@ pub fn get_database_setup_string(db_uri: &String) -> String {
                 }}
 
             impl DB {{
-                pub async fn init() -> Result<Self> {{
-                    let mut client_options = ClientOptions::parse(\"{}\").await?;
-                    client_options.app_name = Some(\"TEST\".to_string());
-                    Ok(Self {{
-                        client: Client::with_options(client_options)?,
-                    }})
+                pub async fn init() -> Result<Self, Error> {{
+                    let client = Client::with_uri_str(\"{}\")
+                        .await
+                        .unwrap();
+                    Ok(DB {{ client }})
                 }}
 
-                pub fn get_collection(&self, db_name: String, collection: String) -> Collection {{
+                pub fn get_collection(&self, db_name: &String, collection: &String) -> Collection {{
                     self.client.database(db_name).collection(collection)
                 }}
-
             }}
-            ",
+           ",
         db_uri
     )
 }
@@ -35,8 +33,8 @@ pub fn get_database_setup_string(db_uri: &String) -> String {
 pub fn get_database_import_string() -> String {
     String::from(
         "\
-        use mongodb::bson::{doc, document::Document, oid::ObjectId, Bson};
-        use mongodb::{options::ClientOptions, Client, Collection};
+        use mongodb::bson::{doc, document::Document, from_bson, Bson};
+        use mongodb::{error::Error, Client, Collection, Cursor};
         ",
     )
 }

--- a/src/writers/file_writer/util_writer/database_generator.rs
+++ b/src/writers/file_writer/util_writer/database_generator.rs
@@ -1,15 +1,13 @@
 //! This module has all of the actual (large) database string generator code,
 //! if DB related code needs to be added/edited this is the first point of contact.
 
+use crate::readers::assembler::WebAPI;
+
 /// Generates a fully contained/functional database system using mongodb.
 ///
 /// Main interface to be used in other generated methods is:
 /// `DB::get_collection(db_name, collection)`.
-pub fn get_database_setup_string(
-    db_uri: &String,
-    db_name: &String,
-    collection_name: &String,
-) -> String {
+pub fn get_database_setup_string(db_info: &DatabaseInfo) -> String {
     format!(
         "
             pub struct DB {{
@@ -29,7 +27,7 @@ pub fn get_database_setup_string(
                 }}
             }}
            ",
-        db_uri, db_name, collection_name,
+        &db_info.db_uri, &db_info.db_name, &db_info.collection_name,
     )
 }
 
@@ -41,4 +39,23 @@ pub fn get_database_import_string() -> String {
         use mongodb::{error::Error, Client, Collection, Cursor};
         ",
     )
+}
+
+/// Super small and simple DB-related struct to hold some variables
+pub struct DatabaseInfo {
+    db_uri: String,
+    db_name: String,
+    collection_name: String,
+}
+
+impl DatabaseInfo {
+    pub fn from_web_api(api_config: &WebAPI, collection_name: String) -> Self {
+        let db_uri = api_config.db_uri.clone();
+        let db_name = api_config.db_name.clone();
+        Self {
+            db_uri,
+            db_name,
+            collection_name,
+        }
+    }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -8,9 +8,26 @@
 
 use crate::readers::assembler::Endpoint;
 
-pub struct UtilBuilder {}
-
+/// Holds all of the ops (altough interface will only call one) for the util builder.
+///
+/// Currently only holds a single piece of data that will be share by all util
+/// methods for the entire API, but obviously is made to be easily expanded upon.
+pub struct UtilBuilder {
+    database_uri: String,
+}
 
 impl UtilBuilder {
-    pub fn
+    /// Constructor takes in only the info that will be required for basically every
+    /// single endpoint regardless of HTTP Verb/other info.
+    ///
+    /// Assumes that database is MongoDB (to be extended at some point)
+    pub fn new(database_uri: String) -> UtilBuilder {
+        UtilBuilder { database_uri }
+    }
+
+    /// Top level function for the builder; assembles and returns a single output-ready
+    /// string with all of the imports, code, etc. that are needed for the util method.
+    pub fn get_util_method_string(&self, endpoint: &Endpoint) -> String {
+        String::from("util file io")
+    }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -109,4 +109,13 @@ impl UtilBuilder {
         // placeholder for now obviously
         imports
     }
+
+    /// Returns string that holds the mongodb client connection
+    /// (only one instance per util file at most)
+    fn mongodb_client_string(&self) -> String {
+        format!(
+            "let client = Client::with_uri_str({}).await.unwrap();\n",
+            &self.database_uri
+        )
+    }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -1,0 +1,16 @@
+//! UtilBuilder creates the output string that actually implements the util methods.
+//!
+//! This includes but is not limited to:
+//! - database queries
+//! - input/output sanitization
+//! - packing/unpacking data into/from (user defined) structs
+//! - etc.
+
+use crate::readers::assembler::Endpoint;
+
+pub struct UtilBuilder {}
+
+
+impl UtilBuilder {
+    pub fn
+}

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -7,7 +7,7 @@
 //! - etc.
 
 use crate::readers::assembler::Endpoint;
-mod database_generator;
+pub mod database_generator;
 mod single_endpoint_generator;
 
 /// Holds all of the ops (altough interface will only call one) for the util builder.
@@ -15,9 +15,7 @@ mod single_endpoint_generator;
 /// Currently only holds a single piece of data that will be share by all util
 /// methods for the entire API, but obviously is made to be easily expanded upon.
 pub struct UtilBuilder {
-    database_uri: String,
-    database_name: String,
-    collection_name: String,
+    db_info: database_generator::DatabaseInfo,
 }
 
 impl UtilBuilder {
@@ -25,16 +23,8 @@ impl UtilBuilder {
     /// single endpoint regardless of HTTP Verb/other info.
     ///
     /// Assumes that database is MongoDB (to be extended at some point)
-    pub fn new(
-        database_uri: String,
-        database_name: String,
-        collection_name: String,
-    ) -> UtilBuilder {
-        UtilBuilder {
-            database_uri,
-            database_name,
-            collection_name,
-        }
+    pub fn new(db_info: database_generator::DatabaseInfo) -> UtilBuilder {
+        UtilBuilder { db_info }
     }
 
     /// Top level function for the builder; assembles and returns a single output-ready
@@ -56,7 +46,10 @@ impl UtilBuilder {
                 );
             final_output_string.push_str(&endpoint_util_string);
         }
+
+        // string gen. for the database related code
         final_output_string.push_str(&self.mongodb_client_string());
+
         final_output_string
     }
 
@@ -86,10 +79,6 @@ impl UtilBuilder {
     fn mongodb_client_string(&self) -> String {
         // This actually just calls an internal module so as to not have to
         // deal/edit the DB string here (too messy/large)
-        database_generator::get_database_setup_string(
-            &self.database_uri,
-            &self.database_name,
-            &self.collection_name,
-        )
+        database_generator::get_database_setup_string(&self.db_info)
     }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -97,6 +97,11 @@ impl UtilBuilder {
     /// Allowing us to make a single util file for a vec of endpoints.
     pub fn get_util_method_string(&self, endpoints: &Vec<&Endpoint>) -> String {
         let mut final_output_string = String::new();
+
+        // add the file-wide import header string
+        final_output_string.push_str(&self.util_import_string());
+
+        // add the code for all of the endpoints (structs, methods, etc.)
         for endpoint in endpoints {
             let endpoint_util_string = UtilEndpointBuilder::get_util_string_from_endpoint(endpoint);
             final_output_string.push_str(&endpoint_util_string);
@@ -105,14 +110,20 @@ impl UtilBuilder {
         final_output_string
     }
 
-    /// Returns a string with the imports needed for the util file
+    /// Returns a string with the imports needed for the util file.
+    ///
+    /// This also includes DB imports
     fn util_import_string(&self) -> String {
         let mut imports = String::new();
-        // placeholder for now obviously
+
+        // get database imports from the database_generator under the hood
+        imports.push_str(&database_generator::get_database_import_string());
+
         imports
     }
 
-    /// Returns string that holds the mongodb client connection
+    /// Returns string that holds the mongodb client connection and
+    /// all of the other relevant DB related structs/implementations
     /// (only one instance per util file at most)
     fn mongodb_client_string(&self) -> String {
         // This actually just calls an internal module so as to not have to

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -16,6 +16,8 @@ mod single_endpoint_generator;
 /// methods for the entire API, but obviously is made to be easily expanded upon.
 pub struct UtilBuilder {
     database_uri: String,
+    database_name: String,
+    collection_name: String,
 }
 
 impl UtilBuilder {
@@ -23,8 +25,16 @@ impl UtilBuilder {
     /// single endpoint regardless of HTTP Verb/other info.
     ///
     /// Assumes that database is MongoDB (to be extended at some point)
-    pub fn new(database_uri: String) -> UtilBuilder {
-        UtilBuilder { database_uri }
+    pub fn new(
+        database_uri: String,
+        database_name: String,
+        collection_name: String,
+    ) -> UtilBuilder {
+        UtilBuilder {
+            database_uri,
+            database_name,
+            collection_name,
+        }
     }
 
     /// Top level function for the builder; assembles and returns a single output-ready
@@ -57,7 +67,7 @@ impl UtilBuilder {
         let mut imports = String::new();
 
         imports.push_str(&format!(
-            "\
+            "
                 use futures::stream::StreamExt;
                 use serde_derive::Deserialize;
                 use tokio;
@@ -76,6 +86,10 @@ impl UtilBuilder {
     fn mongodb_client_string(&self) -> String {
         // This actually just calls an internal module so as to not have to
         // deal/edit the DB string here (too messy/large)
-        database_generator::get_database_setup_string(&self.database_uri)
+        database_generator::get_database_setup_string(
+            &self.database_uri,
+            &self.database_name,
+            &self.collection_name,
+        )
     }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -8,91 +8,7 @@
 
 use crate::readers::assembler::Endpoint;
 mod database_generator;
-
-/// Facade for the actual util builder.
-///
-/// This allows us to build many endpoint util strings while only
-/// making a single UtilBuilder object, which greatly enhances the
-/// overall level of abstraction that callers of this module face.
-struct UtilEndpointBuilder {
-    endpoint: Endpoint,
-}
-
-impl UtilEndpointBuilder {
-    fn get_util_string_from_endpoint(endpoint_ref: &Endpoint) -> String {
-        // setting up the util builder
-        let endpoint = endpoint_ref.clone();
-        let util_builder = UtilEndpointBuilder { endpoint };
-
-        // output string-to-be
-        let mut full_output_string = String::new();
-
-        // response model struct handling
-        full_output_string.push_str(&util_builder.method_return_struct_string());
-
-        // method signature handling
-        full_output_string.push_str(&util_builder.method_signature_string());
-
-        // method body handling
-        full_output_string.push_str(&util_builder.method_body_string());
-
-        full_output_string
-    }
-
-    /// Returns a string with the method signature that matches the one used
-    /// by the `body_writer` mod.
-    fn method_signature_string(&self) -> String {
-        // create the string of params (if none given, 0 len string)
-        let mut param_string = String::new();
-        if let Some(query) = &self.endpoint.query_param {
-            param_string.push_str(&format!("{}: {}, ", query.name, query.field_type));
-        }
-
-        // final output string
-        format!(
-            "async fn {}({}collection: Collection) -> {} {{\n",
-            &self.endpoint.name, param_string, &self.endpoint.return_model_name
-        )
-    }
-
-    /// Creates the method response model as per defined in the input TOML file.
-    ///
-    /// Assumes all types are valid and syntax checks out. If not, relies on post-writing
-    /// compilation/autofmt check to catch the errors (weight on user not system).
-    fn method_return_struct_string(&self) -> String {
-        format!(
-            "\
-            #[derive(Deserialize, Debug)]
-            struct {} {}\n",
-            &self.endpoint.return_model_name, &self.endpoint.return_model
-        )
-    }
-
-    /// Actual method body implementation generator. Most of the work on the module is
-    /// done here. Add features with caution.
-    fn method_body_string(&self) -> String {
-        // not all endpoints will have queries, so depending on that,
-        // the actual generated mongo code will differ.
-
-        let query_string = {
-            if let Some(query) = &self.endpoint.query_param {
-                format!("\"{}\": {}", &query.name, &query.name)
-            } else {
-                format!("")
-            }
-        };
-
-        format!(
-            "\
-            let query = doc! {{{}}};
-            let document = collection.find_one(query, None).await.unwrap().unwrap();
-            let response: {} = from_bson(Bson::Document(document)).unwrap();
-            response
-        }}",
-            query_string, &self.endpoint.return_model_name
-        )
-    }
-}
+mod single_endpoint_generator;
 
 /// Holds all of the ops (altough interface will only call one) for the util builder.
 ///
@@ -124,7 +40,10 @@ impl UtilBuilder {
 
         // add the code for all of the endpoints (structs, methods, etc.)
         for endpoint in endpoints {
-            let endpoint_util_string = UtilEndpointBuilder::get_util_string_from_endpoint(endpoint);
+            let endpoint_util_string =
+                single_endpoint_generator::UtilEndpointBuilder::get_util_string_from_endpoint(
+                    endpoint,
+                );
             final_output_string.push_str(&endpoint_util_string);
         }
         final_output_string.push_str(&self.mongodb_client_string());

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -7,6 +7,7 @@
 //! - etc.
 
 use crate::readers::assembler::Endpoint;
+mod database_generator;
 
 /// Facade for the actual util builder.
 ///
@@ -114,31 +115,8 @@ impl UtilBuilder {
     /// Returns string that holds the mongodb client connection
     /// (only one instance per util file at most)
     fn mongodb_client_string(&self) -> String {
-        format!(
-            "
-            use mongodb::bson::{{doc, document::Document, oid::ObjectId, Bson}};
-            use mongodb::{{options::ClientOptions, Client, Collection}};
-
-            pub struct DB {{
-                pub client: Client,
-                }}
-
-            impl DB {{
-                pub async fn init() -> Result<Self> {{
-                    let mut client_options = ClientOptions::parse(\"{}\").await?;
-                    client_options.app_name = Some(\"TEST\".to_string());
-                    Ok(Self {{
-                        client: Client::with_options(client_options)?,
-                    }})
-                }}
-
-                pub fn get_collection(&self, db_name: String, collection: String) -> Collection {{
-                    self.client.database(db_name).collection(collection)
-                }}
-
-            }}
-            ",
-            &self.database_uri
-        )
+        // This actually just calls an internal module so as to not have to
+        // deal/edit the DB string here (too messy/large)
+        database_generator::get_database_setup_string(&self.database_uri)
     }
 }

--- a/src/writers/file_writer/util_writer/mod.rs
+++ b/src/writers/file_writer/util_writer/mod.rs
@@ -8,6 +8,70 @@
 
 use crate::readers::assembler::Endpoint;
 
+/// Facade for the actual util builder.
+///
+/// This allows us to build many endpoint util strings while only
+/// making a single UtilBuilder object, which greatly enhances the
+/// overall level of abstraction that callers of this module face.
+struct UtilEndpointBuilder {
+    endpoint: Endpoint,
+}
+
+impl UtilEndpointBuilder {
+    fn get_util_string_from_endpoint(endpoint_ref: &Endpoint) -> String {
+        // setting up the util builder
+        let endpoint = endpoint_ref.clone();
+        let util_builder = UtilEndpointBuilder { endpoint };
+
+        // output string-to-be
+        let mut full_output_string = String::new();
+
+        // response model struct handling
+        full_output_string.push_str(&util_builder.method_return_struct_string());
+
+        // method signature handling
+        full_output_string.push_str(&util_builder.method_signature_string());
+
+        // method body handling
+        full_output_string.push_str(&util_builder.method_body_string());
+
+        full_output_string
+    }
+
+    /// Returns a string with the method signature that matches the one used
+    /// by the `body_writer` mod.
+    fn method_signature_string(&self) -> String {
+        // create the string of params (if none given, 0 len string)
+        let mut param_string = String::new();
+        if let Some(query) = &self.endpoint.query_param {
+            param_string.push_str(&format!("{}: {}", query.name, query.field_type));
+        }
+
+        // final output string
+        format!(
+            "async fn {}({}) -> impl Responder {{\n",
+            &self.endpoint.name, param_string
+        )
+    }
+
+    /// Creates the method response model as per defined in the input TOML file.
+    ///
+    /// Assumes all types are valid and syntax checks out. If not, relies on post-writing
+    /// compilation/autofmt check to catch the errors (weight on user not system).
+    fn method_return_struct_string(&self) -> String {
+        format!(
+            "struct {} {}\n",
+            &self.endpoint.return_model_name, &self.endpoint.return_model
+        )
+    }
+
+    /// Actual method body implementation generator. Most of the work on the module is
+    /// done here. Add features with caution.
+    fn method_body_string(&self) -> String {
+        String::new()
+    }
+}
+
 /// Holds all of the ops (altough interface will only call one) for the util builder.
 ///
 /// Currently only holds a single piece of data that will be share by all util
@@ -27,7 +91,22 @@ impl UtilBuilder {
 
     /// Top level function for the builder; assembles and returns a single output-ready
     /// string with all of the imports, code, etc. that are needed for the util method.
-    pub fn get_util_method_string(&self, endpoint: &Endpoint) -> String {
-        String::from("util file io")
+    ///
+    /// Under the hood, this method actually makes calls to the `UtilEndpointBuilder` struct,
+    /// Allowing us to make a single util file for a vec of endpoints.
+    pub fn get_util_method_string(&self, endpoints: &Vec<&Endpoint>) -> String {
+        let mut final_output_string = String::new();
+        for endpoint in endpoints {
+            let endpoint_util_string = UtilEndpointBuilder::get_util_string_from_endpoint(endpoint);
+            final_output_string.push_str(&endpoint_util_string)
+        }
+        final_output_string
+    }
+
+    /// Returns a string with the imports needed for the util file
+    fn util_import_string(&self) -> String {
+        let mut imports = String::new();
+        // placeholder for now obviously
+        imports
     }
 }

--- a/src/writers/file_writer/util_writer/single_endpoint_generator.rs
+++ b/src/writers/file_writer/util_writer/single_endpoint_generator.rs
@@ -1,0 +1,95 @@
+//! Facade for the actual util builder, only handling a single endpoint at a time.
+
+use crate::readers::assembler::Endpoint;
+
+/// Main struct for the `mod` that handles all of the string building.
+///
+/// This allows us to build many endpoint util strings while only
+/// making a single UtilBuilder object, which greatly enhances the
+/// overall level of abstraction that callers of this module face.
+struct UtilEndpointBuilder {
+    endpoint: Endpoint,
+}
+
+impl UtilEndpointBuilder {
+    /// Top level string builder method that returns finished string
+    /// through a single call.
+    ///
+    /// Under the hood just assembling subcalls.
+    ///
+    /// If changes in order of the final output string are needed, or if
+    /// a new component needs to be added, this is the method to edit first.
+    fn get_util_string_from_endpoint(endpoint_ref: &Endpoint) -> String {
+        // setting up the util builder
+        let endpoint = endpoint_ref.clone();
+        let util_builder = UtilEndpointBuilder { endpoint };
+
+        // output string-to-be
+        let mut full_output_string = String::new();
+
+        // response model struct handling
+        full_output_string.push_str(&util_builder.method_return_struct_string());
+
+        // method signature handling
+        full_output_string.push_str(&util_builder.method_signature_string());
+
+        // method body handling
+        full_output_string.push_str(&util_builder.method_body_string());
+
+        full_output_string
+    }
+
+    /// Returns a string with the method signature that matches the one used
+    /// by the `body_writer` mod.
+    fn method_signature_string(&self) -> String {
+        // create the string of params (if none given, 0 len string)
+        let mut param_string = String::new();
+        if let Some(query) = &self.endpoint.query_param {
+            param_string.push_str(&format!("{}: {}, ", query.name, query.field_type));
+        }
+
+        // final output string
+        format!(
+            "async fn {}({}collection: Collection) -> {} {{\n",
+            &self.endpoint.name, param_string, &self.endpoint.return_model_name
+        )
+    }
+
+    /// Creates the method response model as per defined in the input TOML file.
+    ///
+    /// Assumes all types are valid and syntax checks out. If not, relies on post-writing
+    /// compilation/autofmt check to catch the errors (weight on user not system).
+    fn method_return_struct_string(&self) -> String {
+        format!(
+            "\
+            #[derive(Deserialize, Debug)]
+            struct {} {}\n",
+            &self.endpoint.return_model_name, &self.endpoint.return_model
+        )
+    }
+
+    /// Actual method body implementation generator. Most of the work on the module is
+    /// done here. Add features with caution.
+    fn method_body_string(&self) -> String {
+        // not all endpoints will have queries, so depending on that,
+        // the actual generated mongo code will differ.
+
+        let query_string = {
+            if let Some(query) = &self.endpoint.query_param {
+                format!("\"{}\": {}", &query.name, &query.name)
+            } else {
+                format!("")
+            }
+        };
+
+        format!(
+            "\
+            let query = doc! {{{}}};
+            let document = collection.find_one(query, None).await.unwrap().unwrap();
+            let response: {} = from_bson(Bson::Document(document)).unwrap();
+            response
+        }}",
+            query_string, &self.endpoint.return_model_name
+        )
+    }
+}

--- a/src/writers/file_writer/util_writer/single_endpoint_generator.rs
+++ b/src/writers/file_writer/util_writer/single_endpoint_generator.rs
@@ -76,7 +76,7 @@ impl UtilEndpointBuilder {
 
         let query_string = {
             if let Some(query) = &self.endpoint.query_param {
-                format!("\"{}\": {}", &query.name, &query.name)
+                format!("{}", &query.name)
             } else {
                 format!("")
             }

--- a/src/writers/file_writer/util_writer/single_endpoint_generator.rs
+++ b/src/writers/file_writer/util_writer/single_endpoint_generator.rs
@@ -7,7 +7,7 @@ use crate::readers::assembler::Endpoint;
 /// This allows us to build many endpoint util strings while only
 /// making a single UtilBuilder object, which greatly enhances the
 /// overall level of abstraction that callers of this module face.
-struct UtilEndpointBuilder {
+pub struct UtilEndpointBuilder {
     endpoint: Endpoint,
 }
 
@@ -19,7 +19,7 @@ impl UtilEndpointBuilder {
     ///
     /// If changes in order of the final output string are needed, or if
     /// a new component needs to be added, this is the method to edit first.
-    fn get_util_string_from_endpoint(endpoint_ref: &Endpoint) -> String {
+    pub fn get_util_string_from_endpoint(endpoint_ref: &Endpoint) -> String {
         // setting up the util builder
         let endpoint = endpoint_ref.clone();
         let util_builder = UtilEndpointBuilder { endpoint };


### PR DESCRIPTION
- init work on the file writer mod
- added new methods to extract all endpoint data from toml easily
- finished the header writer mod to abstract the creation of import strings
- small refactoring and changing of the body writer. starting full implementation now
- added common http block trait for all future builder implementations
- made the endpoint cloneable and implemented the base set of trait methods for the BodyBuilder mod
- had to make most of the  (and related) fields public, implemented method to get actix macro string
- added new field to the  struct (and toml) for the method name. Finished the method signature impl.
- first pass at implementing the method body writer. Technically works but uses unlinked  call.
- now header string gen. is no longer based off of enpoint (not needed anyway). also fixed/updated imports list and tidied up some code

The idea of this module is to write all of the boilerplate actix method (i.e. route/endpoint) code correctly.

Altough the original name of the structs and etc. was "...Writer" it was swapped to "...Builder" because the module isnt actually performing any I/O.

