### PR TITLE
Cargo.toml dependency injection writer

### DIFF
--- a/src/readers/assembler/mod.rs
+++ b/src/readers/assembler/mod.rs
@@ -10,7 +10,6 @@
 
 use serde_derive::Deserialize;
 use std::fmt;
-use toml;
 
 /// Provides all of the top-level unpacking (deserialization) from the toml file.
 ///
@@ -36,7 +35,7 @@ impl WebAPI {
     ///
     /// *NOTE*: the `toml::from_str` here is unwrapped, meaning that the
     /// error messages passed are not really that great or legible.
-    pub fn parse_toml(toml_str: &String) -> WebAPI {
+    pub fn parse_toml(toml_str: &str) -> WebAPI {
         let parsed_toml: WebAPI = toml::from_str(toml_str).unwrap();
         parsed_toml
     }

--- a/src/readers/parser/mod.rs
+++ b/src/readers/parser/mod.rs
@@ -10,9 +10,8 @@ use std::fs;
 
 /// Arbitrary file-reading util function.
 /// Returns the file data as a single string (for use with the `toml::de::Deserializer`).
-fn read_file_data(filename: &String) -> String {
-    let contents = fs::read_to_string(filename).expect("Unable to read file");
-    contents
+fn read_file_data(filename: &str) -> String {
+    fs::read_to_string(filename).expect("Unable to read file")
 }
 
 /// Main top-level struct that handles all of the reading of the input file.
@@ -29,7 +28,7 @@ impl InputFileReader {
     ///
     /// Reads the file data into a single `str` and uses it to
     /// populate the struct with a `toml::de::Deserializer`.
-    pub fn from_file(filename: &String) -> InputFileReader {
+    pub fn from_file(filename: &str) -> InputFileReader {
         let file_data = read_file_data(filename);
         let toml_data = WebAPI::parse_toml(&file_data);
         InputFileReader { toml_data }

--- a/src/writers/dir_builder/mod.rs
+++ b/src/writers/dir_builder/mod.rs
@@ -1,7 +1,7 @@
 // use crate::readers::assembler::WebAPI;
 use std::fs::{remove_dir_all, DirBuilder};
 use std::io::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Serves as a flag indicator for the (very limited) types of
@@ -139,6 +139,16 @@ impl DirectoryBuilder {
 
     /// Runs `cargo new` for the path to be generated
     fn run_cargo_new(project_name: &String) {
-        Command::new("cargo new").args(&[project_name]);
+        // check if the dir exists, if so, just return early
+        if Path::new(project_name).exists() {
+            return;
+        }
+        // make the directory first
+        DirBuilder::new().create(project_name).unwrap();
+
+        Command::new("cargo")
+            .args(&["init", project_name])
+            .output()
+            .unwrap();
     }
 }

--- a/src/writers/dir_builder/mod.rs
+++ b/src/writers/dir_builder/mod.rs
@@ -18,8 +18,8 @@ pub enum SubDir {
 
 impl SubDir {
     /// Matches the incoming path string to an unwrappable enum
-    fn from_path_str(path_str: &String) -> Self {
-        match path_str.as_str() {
+    fn from_path_str(path_str: &str) -> Self {
+        match path_str {
             "routes" => Self::Routes,
             "util" => Self::Util,
             "models" => Self::Models,
@@ -56,7 +56,7 @@ pub struct DirectoryBuilder {
 impl DirectoryBuilder {
     /// Constructor that takes in the root output directory where all of the
     /// generated code will reside.
-    pub fn new(output_dir_str: &String, group_names: Vec<String>) -> DirectoryBuilder {
+    pub fn new(output_dir_str: &str, group_names: Vec<String>) -> DirectoryBuilder {
         // make the directory builder and allow recursive path building
         let mut dir_builder = DirBuilder::new();
         dir_builder.recursive(true);
@@ -104,7 +104,7 @@ impl DirectoryBuilder {
     pub fn create_base_dir(&self) -> Result<()> {
         // creating the base directory;
         // if an error occurs, hard wipes the directory and retries
-        if let Err(_) = self.dir_builder.create(&self.base_dir) {
+        if self.dir_builder.create(&self.base_dir).is_err() {
             remove_dir_all(&self.base_dir)?;
             self.dir_builder.create(&self.base_dir)?;
         }
@@ -115,7 +115,7 @@ impl DirectoryBuilder {
     ///
     /// Works off of a vector of `SubDir` structs, so adding/removing
     /// subdirs to the overall file hierarchy isn't a nightmare.
-    fn create_sub_directories(&mut self, sub_dirs: &Vec<String>) -> Result<()> {
+    fn create_sub_directories(&mut self, sub_dirs: &[String]) -> Result<()> {
         let mut full_dir = self.base_dir.clone();
 
         // add the group name to the dir to be created for each group
@@ -138,7 +138,7 @@ impl DirectoryBuilder {
     }
 
     /// Runs `cargo new` for the path to be generated
-    fn run_cargo_new(project_name: &String) {
+    fn run_cargo_new(project_name: &str) {
         // check if the dir exists, if so, just return early
         if Path::new(project_name).exists() {
             return;

--- a/src/writers/file_writer/file_output_assembler/main_method_generator/mod.rs
+++ b/src/writers/file_writer/file_output_assembler/main_method_generator/mod.rs
@@ -31,36 +31,33 @@ impl MainMethodBuilder {
 
     /// Get static method string for `main`
     fn get_main_method_import_string() -> String {
-        format!(
-            "
+        "
             use tokio;
             mod users;
             "
-        )
+        .to_string()
     }
 
     /// Returns a string with the method signature that has the
     /// `tokio async` macro header.
     fn method_signature_string() -> String {
-        format!(
-            "
+        "
             #[tokio::main]
             async fn main() {{
             "
-        )
+        .to_string()
     }
 
     /// Main method body string
     fn method_body_string() -> String {
-        format!(
-            "
+        "
             let db = users::util::DB::init().await.unwrap();
             let col = db.get_collection();
             let user_id = String::from(\"123\");
             let user = users::util::find_user_by_id_util(user_id, col).await;
-            println!(\"{{:#?}}\", user);
+            println!(\"{:#?}\", user);
             }}
             "
-        )
+        .to_string()
     }
 }

--- a/src/writers/file_writer/file_output_assembler/mod.rs
+++ b/src/writers/file_writer/file_output_assembler/mod.rs
@@ -51,9 +51,8 @@ impl FileOutputAssembler {
     pub fn get_util_method_string(&self, api_config: &WebAPI) -> String {
         let collection_name = self.group.collection_name.clone();
         let db_info = DatabaseInfo::from_web_api(api_config, collection_name);
-        let util_file_string = self.build_util_method_string(db_info);
 
-        format!("{}", &util_file_string)
+        self.build_util_method_string(db_info)
     }
 
     fn build_util_method_string(&self, db_info: DatabaseInfo) -> String {
@@ -61,8 +60,7 @@ impl FileOutputAssembler {
         // for all of the endpoints at once
         let endpoints = &self.group.get_endpoints();
         let util_builder = util_generator::UtilBuilder::new(db_info);
-        let util_str = util_builder.get_util_method_string(endpoints);
 
-        util_str
+        util_builder.get_util_method_string(endpoints)
     }
 }

--- a/src/writers/file_writer/file_output_assembler/util_generator/mod.rs
+++ b/src/writers/file_writer/file_output_assembler/util_generator/mod.rs
@@ -32,7 +32,7 @@ impl UtilBuilder {
     ///
     /// Under the hood, this method actually makes calls to the `UtilEndpointBuilder` struct,
     /// Allowing us to make a single util file for a vec of endpoints.
-    pub fn get_util_method_string(&self, endpoints: &Vec<&Endpoint>) -> String {
+    pub fn get_util_method_string(&self, endpoints: &[&Endpoint]) -> String {
         let mut final_output_string = String::new();
 
         // add the file-wide import header string
@@ -59,11 +59,7 @@ impl UtilBuilder {
     fn util_import_string(&self) -> String {
         let mut imports = String::new();
 
-        imports.push_str(&format!(
-            "
-                use serde_derive::{{Deserialize, Serialize}};
-        "
-        ));
+        imports.push_str(&"\nuse serde_derive::{{Deserialize, Serialize}};\n".to_string());
 
         // get database imports from the database_generator under the hood
         imports.push_str(&database_generator::get_database_import_string());

--- a/src/writers/file_writer/mod.rs
+++ b/src/writers/file_writer/mod.rs
@@ -8,7 +8,7 @@ use crate::writers::dir_builder::{DirectoryBuilder, SubDir};
 use file_output_assembler::FileOutputAssembler;
 
 pub fn write(api_config: &WebAPI, dir_builder: DirectoryBuilder) -> std::io::Result<()> {
-    let root_dir = dir_builder.base_dir.clone();
+    let root_dir = dir_builder.base_dir;
     let mut file_writer = FileWriter::from_base_dir(root_dir);
 
     // write the main file (outside of group)
@@ -101,12 +101,9 @@ impl FileWriter {
 
     /// Generate the static `mod.rs` string
     fn get_mod_string(&self) -> String {
-        format!(
-            "\
-        pub mod util;
-        pub mod routes;
-        "
-        )
+        "\npub mod util;
+        pub mod routes;\n"
+            .to_string()
     }
 
     /// Doesn't require a path OR a string (same modules get written to always)

--- a/src/writers/post_operator/cargo_dependency_writer.rs
+++ b/src/writers/post_operator/cargo_dependency_writer.rs
@@ -1,7 +1,6 @@
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::path::PathBuf;
-use toml;
 
 fn get_cargo_dependency_string() -> String {
     let dependencies = [
@@ -26,7 +25,7 @@ fn get_cargo_dependency_string() -> String {
 }
 
 /// Writes the `[dependencies]` section of the generated toml file
-pub fn write_cargo_toml_file(base_path_str: &String) -> std::io::Result<()> {
+pub fn write_cargo_toml_file(base_path_str: &str) -> std::io::Result<()> {
     let mut file_path = PathBuf::from(base_path_str);
     file_path.push(String::from("Cargo.toml"));
 
@@ -67,5 +66,6 @@ fn check_written_already(path_str: &PathBuf) -> std::io::Result<bool> {
             }
         }
     }
-    return Ok(false);
+
+    Ok(false)
 }

--- a/src/writers/post_operator/cargo_dependency_writer.rs
+++ b/src/writers/post_operator/cargo_dependency_writer.rs
@@ -25,10 +25,12 @@ fn get_cargo_dependency_string() -> String {
     output_string
 }
 
+/// Writes the `[dependencies]` section of the generated toml file
 pub fn write_cargo_toml_file(base_path_str: &String) -> std::io::Result<()> {
     let mut file_path = PathBuf::from(base_path_str);
     file_path.push(String::from("Cargo.toml"));
 
+    // if the file exists and has been written to, return early (i.e. skip write)
     if let Ok(val) = check_written_already(&file_path) {
         if val {
             return Ok(());
@@ -46,11 +48,13 @@ pub fn write_cargo_toml_file(base_path_str: &String) -> std::io::Result<()> {
     file.write_all(cargo_deps.as_bytes())?;
 
     // write the toml flag to file
-    file.write_all(get_toml_written_string().as_bytes())?;
+    file.write_all(String::from("\n[other]\nwritten = true").as_bytes())?;
 
     Ok(())
 }
 
+/// Returns `Ok(true)` if the file has a `written` flag set to `true`, else
+/// either returns false or returns an error if file is unnaccessible.
 fn check_written_already(path_str: &PathBuf) -> std::io::Result<bool> {
     let contents = std::fs::read_to_string(path_str).expect("Unable to read file");
     let parsed_toml: toml::Value = toml::from_str(&contents)?;
@@ -64,8 +68,4 @@ fn check_written_already(path_str: &PathBuf) -> std::io::Result<bool> {
         }
     }
     return Ok(false);
-}
-
-fn get_toml_written_string() -> String {
-    String::from("\n[other]\nwritten = true")
 }

--- a/src/writers/post_operator/mod.rs
+++ b/src/writers/post_operator/mod.rs
@@ -2,7 +2,7 @@ mod cargo_dependency_writer;
 use std::path::Path;
 use std::process::Command;
 
-fn format_all_rs(path_string: &String) -> std::io::Result<()> {
+fn format_all_rs(path_string: &str) -> std::io::Result<()> {
     // Calls rustfmt on all files ending in .rs within path directory and all subdirectories
     let path = Path::new(path_string);
     Command::new("cargo")
@@ -16,7 +16,7 @@ fn format_all_rs(path_string: &String) -> std::io::Result<()> {
 }
 
 // TODO: find a better name for this function
-pub fn do_post_write_ops(base_path_str: &String) -> std::io::Result<()> {
+pub fn do_post_write_ops(base_path_str: &str) -> std::io::Result<()> {
     format_all_rs(base_path_str)?;
     cargo_dependency_writer::write_cargo_toml_file(base_path_str)?;
 


### PR DESCRIPTION
- added code for a dependency writer to cargo
- removed debug statements
- added checking for cargo init
- some small refactors and more documentation

Has code to open and append the necessary deps. to the generated `Cargo.toml` file only once.

Also writes a flag to the file in order to maintain the once-only transaction
